### PR TITLE
added peak filters for gas levels and other improvements

### DIFF
--- a/HB-UNI-Sen-IAQ.ino
+++ b/HB-UNI-Sen-IAQ.ino
@@ -3,7 +3,7 @@
 // 2016-10-31 papa Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
 // 2019-02-28 jp112sdl (Creative Commons)
 //- -----------------------------------------------------------------------------------------------------------------------
-// #define NDEBUG   // disable all serial debug messages
+//#define NDEBUG   // disable all serial debug messages
 // #define USE_CC1101_ALT_FREQ_86835  //use alternative frequency to compensate not correct working cc1101 modules
 #define SENSOR_ONLY
 
@@ -19,14 +19,15 @@
 #define LED_PIN 4
 #define CONFIG_BUTTON_PIN 8
 #define PEERS_PER_CHANNEL 6
+#define SAMPLINGINTERVALL_IN_SECONDS 240
 
 // all library classes are placed in the namespace 'as'
 using namespace as;
 
 // define all device properties
 const struct DeviceInfo PROGMEM devinfo = {
-  {0xf1, 0xd1, 0x00},     // Device ID
-  "JPIAQ00000",           // Device Serial
+  {0xf1, 0xd1, 0x01},     // Device ID
+  "JPIAQFUEL1",           // Device Serial
   {0xf1, 0xd1},           // Device Model Indoor
   0x10,                   // Firmware Version
   as::DeviceType::THSensor, // Device Type
@@ -122,11 +123,11 @@ class WeatherChannel : public Channel<Hal, List1, EmptyList, List4, PEERS_PER_CH
       clock.add(*this);
       bme680.measure(this->device().getList0().height());
       msg.init( msgcnt,bme680.temperature(),bme680.pressureNN(),bme680.humidity(),bme680.iaq_percent(), bme680.iaq_state(), device().battery().low(), device().battery().current());
-      if (msgcnt % 20 == 1) device().sendPeerEvent(msg, *this); else device().broadcastEvent(msg, *this);
+      if (msgcnt % 80 == 1) device().sendPeerEvent(msg, *this); else device().broadcastEvent(msg, *this);
     }
 
     uint32_t delay () {
-      return seconds2ticks(max(this->device().getList0().updIntervall(),10));
+      return seconds2ticks(max(this->device().getList0().updIntervall(),SAMPLINGINTERVALL_IN_SECONDS));
     }
     void setup(Device<Hal, SensorList0>* dev, uint8_t number, uint16_t addr) {
       Channel::setup(dev, number, addr);
@@ -174,5 +175,3 @@ void loop() {
     hal.activity.savePower<Sleep<>>(hal);
   }
 }
-
-

--- a/sensors/sens_bme680.h
+++ b/sensors/sens_bme680.h
@@ -17,15 +17,19 @@
  */
 
 #define HUM_REFERENCE   40.0
-#define HUM_WEIGHTING   0.25      // so hum effect is 25% of the total air quality score
-#define GAS_WEIGHTING   0.75      // so gas effect is 75% of the total air quality score
-#define GAS_LOWER_LIMIT 20000.0    // Bad air quality limit
-#define GAS_UPPER_LIMIT 300000.0  // Good air quality limit
+#define HUM_WEIGHTING   0.00      // so hum effect is 0% of the total air quality score, default is 25%
+#define GAS_WEIGHTING   (1.00-(HUM_WEIGHTING))      // so gas effect is 100% of the total air quality score, default is 75%; sum of HUM_WEIGHTING and GAS_WEIGHTING is 1.0
+#define HUM_DELTA       5.0       // band around HUM_REFERENCE for best humidity, i.e. 35% .. 45% relative humidity as default
+#define GAS_LOWER_LIMIT 2000.0    // Bad air quality limit 2kOhm
+#define GAS_UPPER_LIMIT 170000.0  // Good air quality limit 170kOhm
 #define AVG_COUNT       1
+#define IIR_FILTER_COEFFICIENT 0.9998641  // Decay to 0.71 in about one week for a 4 min sampling period (in 2520 sampling periods)
+#define GAS_FACTOR      0.25      // for calclulating the _gas_score the upper gas limit is scaled by this factor in order to get more meaningful results for indoor sensors
+                                  // GAS_FACTOR should be set to 1.0 for an outdoor sensor
 
 namespace as {
 
-template <uint8_t ADDRESS=0x77>
+template <uint8_t ADDRESS=0x76>  // I2C address needs to be be set according to your BME680 sensor breakout
 class Sens_Bme680 : public Sensor {
 private:
   int16_t   _temperature;
@@ -33,6 +37,10 @@ private:
   uint8_t   _humidity;
   uint16_t  _iaqPercent;
   uint8_t   _iaqState;
+  uint32_t  _max_gas_resistance;  // maximum measured gas resistance
+  uint32_t  _min_gas_resistance;  // minimum measured gas resistance
+  uint32_t  _gas_lower_limit;     // adaptive lower resistance level for bad air quality
+  uint32_t  _gas_upper_limit;     // adaptive upper resistance level for good air quality
 
   ClosedCube_BME680 _bme680;
 public:
@@ -60,6 +68,12 @@ public:
     _bme680.setIIRFilter(BME680_FILTER_3);
     _bme680.setGasOn(320, 150); // 300 degree Celsius and 100 milliseconds
     _bme680.setForcedMode();
+    
+    _max_gas_resistance = 0;
+    _min_gas_resistance = 1000000;
+    _gas_upper_limit = GAS_UPPER_LIMIT;
+    _gas_lower_limit = GAS_LOWER_LIMIT;
+    
   }
 
   float EquivalentSeaLevelPressure(float altitude, float temp, float pres) {
@@ -115,15 +129,49 @@ public:
       }
       gas /= AVG_COUNT;
       DDECLN(gas);
+      
+      if ( gas > _max_gas_resistance)    // capture maximum of measured gas resistances
+        _max_gas_resistance = gas;
+      if ( gas < _min_gas_resistance)    // capture minimum of measured gas resistances
+        _min_gas_resistance = gas;
+      
+      //peak detector for _gas_upper_limit 
+      if ( gas > _gas_upper_limit )
+      {
+        _gas_upper_limit = gas;
+      }
+      else
+      {
+        _gas_upper_limit = _gas_upper_limit * IIR_FILTER_COEFFICIENT; // decay each sample by IIR_FILTER_COEFFICIENT
+        if ( _gas_upper_limit < GAS_UPPER_LIMIT )
+          _gas_upper_limit = GAS_UPPER_LIMIT; // lower limit for _gas_upper_limit
+      }
+      
+      //peak detector for _gas_lower_limit 
+      if ( gas < _gas_lower_limit )
+      {
+        _gas_lower_limit = gas;
+      }
+      else
+      {
+        _gas_lower_limit = _gas_lower_limit / IIR_FILTER_COEFFICIENT; // increase each sample by 1.0/IIR_FILTER_COEFFICIENT
+        if ( _gas_lower_limit > GAS_LOWER_LIMIT )
+          _gas_lower_limit = GAS_LOWER_LIMIT; // upper limit for _gas_lower_limit
+      }
+      
       _temperature = (int16_t)(temp * 10);
       _pressureNN  = (uint16_t)(EquivalentSeaLevelPressure(float(height), temp, pres) * 10);
       _humidity    = (uint8_t)hum;
+      
+      DPRINT(F("Gas UPPER LIMIT   = "));DDECLN(_gas_upper_limit);
+      DPRINT(F("Gas LOWER LIMIT   = "));DDECLN(_gas_lower_limit);
 
       DPRINT(F("T   = "));DDECLN(_temperature);
       DPRINT(F("P   = "));DDECLN(pres);
       DPRINT(F("PNN = "));DDECLN(_pressureNN);
       DPRINT(F("Hum = "));DDECLN(_humidity);
       DPRINT(F("Gas = "));DDECLN(gas);
+      DPRINT(F("Gas FACTOR = "));DDECLN(GAS_FACTOR);
 
       /*
        This software, the ideas and concepts is Copyright (c) David Bird 2018. All rights to this software are reserved.
@@ -146,33 +194,44 @@ public:
         //Calculate humidity contribution to IAQ index
       float _hum_score = 0.0;
       float _gas_score = 0.0;
-        if (hum >= 38 && hum <= 42)
-          _hum_score = 0.25*100; // Humidity +/-5% around optimum
-        else
-        { //sub-optimal
-          if (hum < 38)
-            _hum_score = 0.25/HUM_REFERENCE*hum*100;
+      if (hum >= HUM_REFERENCE - HUM_DELTA && hum <= HUM_REFERENCE + HUM_DELTA)
+        _hum_score = HUM_WEIGHTING*100.0; // Humidity +/-HUM_DELTA% around optimum HUM_REFERENCE; region 0
+      else
+      { //sub-optimal, trapezoid function: 0 @ hum=0; HUM_WEIGHTING @ hum = HUM_REFERENCE - HUM_DELTA; HUM_WEIGHTING @ hum = HUM_REFERENCE + HUM_DELTA; 0 for hum >= HUM_REFERENCE + HUM_DELTA;
+        if (hum < HUM_REFERENCE - HUM_DELTA)
+          _hum_score = HUM_WEIGHTING/(HUM_REFERENCE - HUM_DELTA)*hum*100.0; // region 1; zero for hum = 0, continuous at hum = HUM_REFERENCE - HUM_DELTA
+        else // (hum > HUM_REFERENCE + HUM_DELTA)
+        {
+          if ( hum >= 2 * HUM_REFERENCE )
+            _hum_score = 0.0;
           else
           {
-            _hum_score = ((-0.25/(100-HUM_REFERENCE)*hum)+0.416666)*100;
+            _hum_score = (-HUM_WEIGHTING/(HUM_REFERENCE - HUM_DELTA)*(hum-2*HUM_REFERENCE))*100.0; // region 2; negative slope of region 1; zero for hum = 2 * HUM_REFERENCE, continuous at hum = HUM_REFERENCE + HUM_DELTA
           }
         }
+      }
+      
+      // limit gas values
+      if (gas > _gas_upper_limit) gas = _gas_upper_limit;
+      if (gas < _gas_lower_limit) gas = _gas_lower_limit;
+        
+      //DPRINT(F("gRef= "));DDECLN(_gas_reference);
 
-        if (gas > GAS_UPPER_LIMIT) gas = GAS_UPPER_LIMIT;
-        if (gas < GAS_LOWER_LIMIT) gas = GAS_LOWER_LIMIT;
-        //DPRINT(F("gRef= "));DDECLN(_gas_reference);
+      _gas_score = ( GAS_WEIGHTING/(_gas_upper_limit*GAS_FACTOR-_gas_lower_limit)*gas - GAS_WEIGHTING*_gas_lower_limit/(_gas_upper_limit*GAS_FACTOR-_gas_lower_limit))*100.0;
+      
+      if ( _gas_score > 100.0 )
+        _gas_score = 100.0;
 
-        _gas_score = (0.75/(GAS_UPPER_LIMIT-GAS_LOWER_LIMIT)*gas -(GAS_LOWER_LIMIT*(0.75/(GAS_UPPER_LIMIT-GAS_LOWER_LIMIT))))*100;
+        
+      //Combine results for the final IAQ index value (0-100% where 100% is good quality air)
+      float air_quality_score = _hum_score + _gas_score;
 
-        //Combine results for the final IAQ index value (0-100% where 100% is good quality air)
-        float air_quality_score = _hum_score + _gas_score;
-
-        _iaqState = CalculateIAQ(air_quality_score);
-        _iaqPercent = (uint8_t)(air_quality_score);
-        //DPRINT(F("AQ% = "));DDECLN(_iaqPercent);
-        //DPRINT(F("AQS = "));DDECLN(_iaqState);
-        DPRINT(F("AQ  = "));DDEC((uint8_t)air_quality_score);DPRINT(F("% (H: "));DDEC((uint8_t)(_hum_score));DPRINT(F("% + G: "));DDEC((uint8_t)(_gas_score));DPRINTLN(F("%)"));
-        _bme680.setForcedMode();
+      _iaqState = CalculateIAQ(air_quality_score);
+      _iaqPercent = (uint8_t)(air_quality_score);
+      //DPRINT(F("AQ% = "));DDECLN(_iaqPercent);
+      //DPRINT(F("AQS = "));DDECLN(_iaqState);
+      DPRINT(F("AQ  = "));DDEC((uint8_t)air_quality_score);DPRINT(F("% (H: "));DDEC((uint8_t)(_hum_score));DPRINT(F("% + G: "));DDEC((uint8_t)(_gas_score));DPRINTLN(F("%)"));
+      _bme680.setForcedMode();
     }
   }
   


### PR DESCRIPTION
Hi Jérôme,

this pull request includes the following improvements:

1. adaptive peak filters for  GAS_LOWER_LIMIT and GAS_UPPER_LIMIT
2. HUM_WEIGHTING can be set to zero, i.e. no influence of the humidity to the IAQ
3. Introduction of GAS_FACTOR to get meaningful indoor IAQ values
4. Adjustment of _hum_score formula to get a trapezoid behavior, see comments
5. Set sampling period to 240 seconds

Best regards,

Ewald



